### PR TITLE
chore: re-export projection in datafusion::datasource

### DIFF
--- a/datafusion/core/src/datasource/mod.rs
+++ b/datafusion/core/src/datasource/mod.rs
@@ -42,6 +42,7 @@ pub use datafusion_catalog::default_table_source;
 pub use datafusion_catalog::memory;
 pub use datafusion_catalog::stream;
 pub use datafusion_catalog::view;
+pub use datafusion_datasource::projection;
 pub use datafusion_datasource::schema_adapter;
 pub use datafusion_datasource::sink;
 pub use datafusion_datasource::source;


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

So I won't have to specify another crate

## What changes are included in this PR?

re-export

## Are these changes tested?
No

## Are there any user-facing changes?

Yes, can be used from `datafusion::datasource`